### PR TITLE
Fix 'gulp-testcafe doesn't work' (close #14)

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ var DEFAULT_OPTS = {
     hostname:              '',
     ports:                 [],
     speed:                 1,
-    concurrency:           0,
+    concurrency:           1,
     app:                   '',
     appInitDelay:          1000,
     debugMode:             false,

--- a/package.json
+++ b/package.json
@@ -60,9 +60,9 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "4.18.2",
-    "mocha": "^3.0.2",
+    "mocha": "^6.2.1",
     "promisify-event": "^1.0.0",
-    "publish-please": "^2.2.0",
+    "publish-please": "^5.5.1",
     "vinyl-file": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-testcafe",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Run TestCafe tests using Gulp.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
https://github.com/DevExpress/gulp-testcafe/issues/14

### Changes
1. Set the default `concurrency` option value to `1`.
2. Fix vulnerabilities.
3. Bump version.