### PR TITLE
replace gulp-util with plugin-error (github.com/gulpjs/plugin-error)

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var fs             = require('fs');
 var defaults       = require('lodash.defaults');
 var flatten        = require('lodash.flatten');
 var createTestCafe = require('testcafe');
-var PluginError    = require('gulp-util').PluginError;
+var PluginError    = require('plugin-error');
 var through        = require('through2');
 
 var DEFAULT_REPORTER = 'spec';

--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
   },
   "homepage": "https://github.com/DevExpress/gulp-testcafe#readme",
   "dependencies": {
-    "gulp-util": "^3.0.7",
     "lodash.defaults": "^4.2.0",
     "lodash.flatten": "^4.4.0",
+    "plugin-error": "^1.0.1",
     "testcafe": "latest",
     "through2": "^2.0.1"
   },


### PR DESCRIPTION
as gulp-util is deprecated
