### PR TITLE
Adding support for screenshot.pathPattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var DEFAULT_OPTS = {
     filter:                null,
     screenshotsPath:       null,
     takeScreenshotsOnFail: false,
-    pathPattern:           '${DATE}_${TIME}/${TEST_ID}/${RUN_ID}/${USERAGENT}/${FILE_INDEX}.png',
+    pathPattern:           null,
     reporter:              [],
     skipJsErrors:          false,
     quarantineMode:        false,

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var DEFAULT_OPTS = {
     filter:                null,
     screenshotsPath:       null,
     takeScreenshotsOnFail: false,
+    pathPattern:           '${DATE}_${TIME}/${TEST_ID}/${RUN_ID}/${USERAGENT}/${FILE_INDEX}.png',
     reporter:              [],
     skipJsErrors:          false,
     quarantineMode:        false,
@@ -73,7 +74,7 @@ module.exports = function gulpTestCafe (opts) {
                     .src(files)
                     .browsers(opts.browsers)
                     .filter(opts.filter)
-                    .screenshots(opts.screenshotsPath, opts.takeScreenshotsOnFail)
+                    .screenshots(opts.screenshotsPath, opts.takeScreenshotsOnFail, opts.pathPattern)
                     .reporter(opts.reporter);
 
                 if (opts.concurrency)


### PR DESCRIPTION
Adding support to be able to specify a custom pattern to compose screenshot files' relative path and name.